### PR TITLE
ci: use my own, patched, CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
   check:
-    uses: vtavernier/github-workflows/.github/workflows/check-rust.yml@v1
+    uses: iTrooz/vtavernier-github-workflows/.github/workflows/check-rust.yml@v1
 
   build:
-    uses: vtavernier/github-workflows/.github/workflows/build-rust-bin.yml@v1
+    uses: iTrooz/vtavernier-github-workflows/.github/workflows/build-rust-bin.yml@v1
 
     needs:
       - check
@@ -45,7 +45,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
   release:
-    uses: vtavernier/github-workflows/.github/workflows/release-semantic.yml@v1
+    uses: iTrooz/vtavernier-github-workflows/.github/workflows/release-semantic.yml@v1
 
     needs:
       - build

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   pullrequest:
-    uses: vtavernier/github-workflows/.github/workflows/pullrequest-semantic.yml@v1
+    uses: iTrooz/vtavernier-github-workflows/.github/workflows/pullrequest-semantic.yml@v1


### PR DESCRIPTION
Right now, the only patch is to use the codecov token to try to avoid upload errors (rate-limit ?)