### PR TITLE
chore: put myself in CODEOWNERS file instead of @vtavernier

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vtavernier
+* @iTrooz


### PR DESCRIPTION
Rationale: This file decides who will be notified for review requests