### PR TITLE
fix: remove file_store_std()

### DIFF
--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -102,7 +102,7 @@ struct Opt {
 #[paw::main]
 fn main(opts: Opt) {
     let manager = if let Some(filename) = opts.file_store {
-        efivar::file_store_std(filename)
+        efivar::file_store(filename)
     } else {
         efivar::system()
     };

--- a/efivar/src/lib.rs
+++ b/efivar/src/lib.rs
@@ -101,13 +101,6 @@ pub fn file_store<P: Into<std::path::PathBuf>>(filename: P) -> Box<dyn VarManage
     Box::new(store::FileStore::new(filename.into()))
 }
 
-#[cfg(feature = "store")]
-#[doc(hidden)]
-pub fn file_store_std<P: Into<std::path::PathBuf>>(filename: P) -> Box<dyn VarManager> {
-    // TODO: Fix this knowing that VarManagerEx: VarManager
-    Box::new(store::FileStore::new(filename.into()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Useless since https://github.com/iTrooz/efiboot-rs/pull/67