### PR TITLE
fix: implement uuid parsing according to RFC4122

### DIFF
--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -1,6 +1,6 @@
 //! This module contains parsing code for a device path, part of a device path list
 
-use std::{convert::TryInto, fmt::Display, io::Write, mem::transmute, path::PathBuf};
+use std::{convert::TryInto, fmt::Display, io::Write, path::PathBuf};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use uuid::Uuid;
@@ -78,12 +78,9 @@ impl EFIHardDrive {
                     .map_err(|_| Error::VarParseError)?,
                 buf.read_u16::<LittleEndian>()
                     .map_err(|_| Error::VarParseError)?,
-                unsafe {
-                    &transmute::<u64, [u8; 8]>(
-                        buf.read_u64::<LittleEndian>()
-                            .map_err(|_| Error::VarParseError)?,
-                    )
-                },
+                &buf.read_u64::<LittleEndian>()
+                    .map_err(|_| Error::VarParseError)?
+                    .to_le_bytes(),
             ),
             format: buf.read_u8().map_err(|_| Error::VarParseError)?,
             sig_type: EFIHardDriveType::parse(buf.read_u8().map_err(|_| Error::VarParseError)?),

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -1,8 +1,8 @@
 //! This module contains parsing code for a device path, part of a device path list
 
-use std::{convert::TryInto, fmt::Display, io::Write, path::PathBuf};
+use std::{convert::TryInto, fmt::Display, io::Write, mem::transmute, path::PathBuf};
 
-use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use uuid::Uuid;
 
 use crate::{utils::read_nt_utf16_string, Error};
@@ -59,6 +59,38 @@ pub struct EFIHardDrive {
     pub sig_type: EFIHardDriveType,
 }
 
+impl EFIHardDrive {
+    pub fn parse(buf: &mut &[u8]) -> crate::Result<EFIHardDrive> {
+        Ok(EFIHardDrive {
+            partition_number: buf
+                .read_u32::<LittleEndian>()
+                .map_err(|_| Error::VarParseError)?,
+            partition_start: buf
+                .read_u64::<LittleEndian>()
+                .map_err(|_| Error::VarParseError)?,
+            partition_size: buf
+                .read_u64::<LittleEndian>()
+                .map_err(|_| Error::VarParseError)?,
+            partition_sig: Uuid::from_fields(
+                buf.read_u32::<LittleEndian>()
+                    .map_err(|_| Error::VarParseError)?,
+                buf.read_u16::<LittleEndian>()
+                    .map_err(|_| Error::VarParseError)?,
+                buf.read_u16::<LittleEndian>()
+                    .map_err(|_| Error::VarParseError)?,
+                unsafe {
+                    &transmute::<u64, [u8; 8]>(
+                        buf.read_u64::<LittleEndian>()
+                            .map_err(|_| Error::VarParseError)?,
+                    )
+                },
+            ),
+            format: buf.read_u8().map_err(|_| Error::VarParseError)?,
+            sig_type: EFIHardDriveType::parse(buf.read_u8().map_err(|_| Error::VarParseError)?),
+        })
+    }
+}
+
 impl Display for EFIHardDrive {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -93,30 +125,7 @@ impl DevicePath {
                     })));
                 }
                 consts::MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE => {
-                    return Ok(Some(DevicePath::HardDrive(EFIHardDrive {
-                        partition_number: device_path_data
-                            .read_u32::<LittleEndian>()
-                            .map_err(|_| Error::VarParseError)?,
-                        partition_start: device_path_data
-                            .read_u64::<LittleEndian>()
-                            .map_err(|_| Error::VarParseError)?,
-                        partition_size: device_path_data
-                            .read_u64::<LittleEndian>()
-                            .map_err(|_| Error::VarParseError)?,
-                        partition_sig: Uuid::from_u128(
-                            device_path_data
-                                .read_u128::<BigEndian>()
-                                .map_err(|_| Error::VarParseError)?,
-                        ),
-                        format: device_path_data
-                            .read_u8()
-                            .map_err(|_| Error::VarParseError)?,
-                        sig_type: EFIHardDriveType::parse(
-                            device_path_data
-                                .read_u8()
-                                .map_err(|_| Error::VarParseError)?,
-                        ),
-                    })));
+                    return Ok(Some(DevicePath::HardDrive(EFIHardDrive::parse(&mut device_path_data)?)));
                 }
                 _ => {}
             },
@@ -156,7 +165,12 @@ impl EFIHardDrive {
         bytes
             .write_u64::<LittleEndian>(self.partition_size)
             .unwrap();
-        bytes.write_all(self.partition_sig.as_bytes()).unwrap();
+
+        let (f1, f2, f3, f4) = self.partition_sig.as_fields();
+        bytes.write_u32::<LittleEndian>(f1).unwrap();
+        bytes.write_u16::<LittleEndian>(f2).unwrap();
+        bytes.write_u16::<LittleEndian>(f3).unwrap();
+        bytes.write_all(f4).unwrap();
         bytes.write_u8(self.format).unwrap();
         bytes.write_u8(self.sig_type.as_u8()).unwrap();
 
@@ -262,5 +276,21 @@ mod tests {
                 }
             )
         );
+    }
+
+    #[test]
+    fn to_from_bytes() {
+        let drive = EFIHardDrive {
+            partition_number: 1,
+            partition_start: 2,
+            partition_size: 3,
+            partition_sig: Uuid::from_str("90364bbd-1000-47fc-8c05-8707e01b4593").unwrap(),
+            format: 5,
+            sig_type: EFIHardDriveType::Gpt,
+        };
+        let bytes = drive.to_bytes_raw();
+        let mut x = bytes.as_slice();
+        let test_parse = EFIHardDrive::parse(&mut x).unwrap();
+        assert_eq!(drive, test_parse)
     }
 }

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -125,7 +125,9 @@ impl DevicePath {
                     })));
                 }
                 consts::MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE => {
-                    return Ok(Some(DevicePath::HardDrive(EFIHardDrive::parse(&mut device_path_data)?)));
+                    return Ok(Some(DevicePath::HardDrive(EFIHardDrive::parse(
+                        &mut device_path_data,
+                    )?)));
                 }
                 _ => {}
             },

--- a/efivar/src/boot/parse/tests/dump.rs
+++ b/efivar/src/boot/parse/tests/dump.rs
@@ -19,7 +19,7 @@ fn dump() {
                 partition_number: 1,
                 partition_start: 10240,
                 partition_size: 991232,
-                partition_sig: Uuid::from_str("0ac986f5-a335-f2a8-4943-3ef0837cdce3").unwrap(),
+                partition_sig: Uuid::from_str("f586c90a-35a3-a8f2-4943-3ef0837cdce3").unwrap(),
                 format: 2,
                 sig_type: crate::boot::EFIHardDriveType::Gpt,
             },

--- a/efivar/src/boot/parse/tests/parse.rs
+++ b/efivar/src/boot/parse/tests/parse.rs
@@ -31,7 +31,7 @@ fn parse() {
                     partition_number: 1,
                     partition_start: 10240,
                     partition_size: 991232,
-                    partition_sig: Uuid::from_str("e3dc7c83-f03e-4349-a8f2-35a3f586c90a").unwrap(),
+                    partition_sig: Uuid::from_str("837cdce3-3ef0-4943-a8f2-35a3f586c90a").unwrap(),
                     format: 2,
                     sig_type: crate::boot::EFIHardDriveType::Gpt,
                 }


### PR DESCRIPTION
While trying to use the efivars variable to read my boot configuration I noticed that the displayed uuid did not match the actual uuid of my EFI partition. After some digging it turned out that the current implementation does not comply with the [UEFI Specification for GUID](https://uefi.org/specs/UEFI/2.9_A/Apx_A_GUID_and_Time_Formats.html)

This PR fixes the parsing and byte serialization. Not sure if there are other parts of the codebase where this might be required as well.